### PR TITLE
Add close survey and view responses functionality 

### DIFF
--- a/src/main/java/org/surveymonkey/controllers/SurveyController.java
+++ b/src/main/java/org/surveymonkey/controllers/SurveyController.java
@@ -64,14 +64,18 @@ public class SurveyController {
         model.addAttribute("choiceQuestions", choiceQuestionList);
 
         return "doSurvey";
-        //return "surveyTable";
     }
 
     @GetMapping(value = "/survey/{surveyID}/fill")
     public String fillSurvey(@PathVariable long surveyID, Model model) {
-        model.addAttribute("survey", surveyService.findById(surveyID));
+        Survey s = surveyService.findById(surveyID);
+        if(s.isClosed()) {
+            // Don't add response if Survey is closed
+            return "redirect:/survey/" + surveyID;
+        }
+        model.addAttribute("survey", s);
 
-        List<Question> questionList = surveyService.findById(surveyID).getQuestions();
+        List<Question> questionList = s.getQuestions();
         ArrayList<TextQuestion> textQuestionList = new ArrayList<>();
         ArrayList<NumberQuestion> numberQuestionList = new ArrayList<>();
         ArrayList<ChoiceQuestion> choiceQuestionList = new ArrayList<>();
@@ -96,7 +100,11 @@ public class SurveyController {
 
     @PostMapping(value = "/survey/{surveyID}/fill", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
     public String fillSurveyComplete(@RequestBody MultiValueMap<String, String> formData, @PathVariable long surveyID) {
-
+        Survey s = surveyService.findById(surveyID);
+        if(s.isClosed()) {
+            // Don't add response if Survey is closed
+            return "redirect:/survey/" + surveyID;
+        }
         for (Map.Entry formElement : formData.entrySet()) {
             String formKey = (String) formElement.getKey();
             String formValue = (String) ((LinkedList) formElement.getValue()).getFirst();
@@ -139,6 +147,34 @@ public class SurveyController {
     public String addQuestion(@PathVariable long surveyID, Model model) {
         model.addAttribute("survey", surveyService.findById(surveyID));
         return "createQuestion";
+    }
+
+    /**
+     * View the responses of a survey
+     * @param surveyID Survey to view responses of
+     * @param model
+     * @return Renders a view containing survey responses
+     */
+    @GetMapping(value = "/survey/{surveyID}/responses")
+    public String surveyResponses(@PathVariable long surveyID, Model model) {
+        Survey survey = surveyService.findById(surveyID);
+        List<Question> questionList = survey.getQuestions();
+        model.addAttribute("survey", survey);
+        model.addAttribute("questions", questionList);
+        return "viewResponses";
+    }
+
+    /**
+     * This action allows a user to close a Survey
+     * @param surveyID Survey to close
+     * @return Redirect user to main Survey view page
+     */
+    @PostMapping(value = "/survey/{surveyID}/close")
+    public String closeQuestion(@PathVariable long surveyID) {
+        Survey survey = surveyService.findById(surveyID);
+        survey.markAsClosed();
+        surveyService.save(survey);
+        return "redirect:/survey/" + surveyID;
     }
 
     @GetMapping(value = "/SurveyControllerController/test")

--- a/src/main/resources/templates/doSurvey.html
+++ b/src/main/resources/templates/doSurvey.html
@@ -67,6 +67,13 @@
 <a th:href="${survey.getId() + '/fill'}">
     Fill out this survey
 </a>
-
+<p th:text="${survey.isClosed()} ? 'Survey is closed' : 'Survey is accepting responses'"/>
+</p>
+<form th:if="${survey.isClosed() == false}" th:action="@{/survey/__${survey.getId()}__/close}" method="post" id="closeForm">
+    <button type="submit" form="closeForm" value="Close">Close Survey</button>
+</form>
+<a th:if="${survey.isClosed() == true}" th:href="${survey.getId() + '/responses'}">
+    View responses
+</a>
 </body>
 </html>

--- a/src/main/resources/templates/viewResponses.html
+++ b/src/main/resources/templates/viewResponses.html
@@ -1,0 +1,23 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head th:include="fragments/header :: header">
+    <title>Survey Responses</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+</head>
+<body>
+    <main>
+
+        <div th:each="question : ${questions}">
+            <h2 th:text="${question.getQuestion()}">
+
+            </h2>
+
+            <ul th:each="answer : ${question.getAnswers()}" >
+                <li th:text="${answer}">
+
+                </li>
+            </ul>
+        </div>
+    </main>
+</body>
+</html>


### PR DESCRIPTION
Users can now close their survey, and after they've closed it, a link to view responses will appear.

Need to do some more work on the frontend for this, but it is a basic implementation of the data so far.