### PR TITLE
Fix broken share link

### DIFF
--- a/src/main/java/org/surveymonkey/controllers/ApplicationController.java
+++ b/src/main/java/org/surveymonkey/controllers/ApplicationController.java
@@ -35,6 +35,6 @@ public class ApplicationController {
 
     @ModelAttribute("hostName")
     public String hostname() {
-        return InetAddress.getLoopbackAddress().getHostAddress();
+        return "https://sysc4806groupproject.herokuapp.com";
     }
 }


### PR DESCRIPTION
Quick PR to fix the permanent 127.0.0.1 share link.


Resolves #131